### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@
  */
 var events = require("events");
 var url = require("url");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 var msgpack = require("msgpack-lite");
 var traverse = require("traverse");
 

--- a/lib/transport-http-server.js
+++ b/lib/transport-http-server.js
@@ -8,7 +8,7 @@
  */
 var events = require("events");
 var url = require("url");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 // This function is exposed to the module's `transport` module's `createHttpServer` as a factory
 // to create server which consumes HTTP request-response exchange and produces transport.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "msgpack-lite": "0.1.17",
-    "node-uuid": "1.4.7",
     "traverse": "0.6.6",
+    "uuid": "^3.0.0",
     "ws": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.